### PR TITLE
feat: handle conflict checks during updates

### DIFF
--- a/internal/provider/resource_usergroup.go
+++ b/internal/provider/resource_usergroup.go
@@ -420,9 +420,9 @@ func findUserGroupByField(
 		var matches bool
 		switch searchField {
 		case "name":
-			matches = (g.Name == searchVal)
+			matches = strings.EqualFold(g.Name, searchVal)
 		case "handle":
-			matches = (g.Handle == searchVal)
+			matches = strings.EqualFold(g.Handle, searchVal)
 		case "id":
 			matches = (g.ID == searchVal)
 		default:


### PR DESCRIPTION
`prevent_conflicts=true` wasn't working when updating an existing group resource to a conflicting name/handle, this MR should fix that. Because it's actually checking for conflicts during updates now it also slows down `plan` a lot, but there is still room for improvement to optimize the frequency of requests done by findUserGroupByField() in the future. Users can set `prevent_conflicts` via environment variables only in PR pipelines for example to optimize `plan` times until then.